### PR TITLE
Feature/ignore unknown error

### DIFF
--- a/include/ooqp_eigen_interface/OoqpEigenInterface.hpp
+++ b/include/ooqp_eigen_interface/OoqpEigenInterface.hpp
@@ -79,7 +79,8 @@ class OoqpEigenInterface
                     Eigen::SparseMatrix<double, Eigen::RowMajor>& C,
                     Eigen::VectorXd& d, Eigen::VectorXd& f,
                     Eigen::VectorXd& l, Eigen::VectorXd& u,
-                    Eigen::VectorXd& x);
+                    Eigen::VectorXd& x,
+                    bool ignoreUnknownError = false);
 
   /*!
    * Solve min 1/2 x' Q x + c' x, such that A x = b, and d <= Cx <= f
@@ -99,7 +100,8 @@ class OoqpEigenInterface
                     Eigen::VectorXd& b,
                     Eigen::SparseMatrix<double, Eigen::RowMajor>& C,
                     Eigen::VectorXd& d, Eigen::VectorXd& f,
-                    Eigen::VectorXd& x);
+                    Eigen::VectorXd& x,
+                    bool ignoreUnknownError = false);
 
   /*!
    * Solve min 1/2 x' Q x + c' x, such that A x = b, and l <= x <= u.
@@ -117,7 +119,8 @@ class OoqpEigenInterface
                     Eigen::SparseMatrix<double, Eigen::RowMajor>& A,
                     Eigen::VectorXd& b,
                     Eigen::VectorXd& l, Eigen::VectorXd& u,
-                    Eigen::VectorXd& x);
+                    Eigen::VectorXd& x,
+                    bool ignoreUnknownError = false);
 
   /*!
    * Solve min 1/2 x' Q x + c' x, such that Cx <= f
@@ -132,7 +135,8 @@ class OoqpEigenInterface
                     Eigen::VectorXd& c,
                     Eigen::SparseMatrix<double, Eigen::RowMajor>& C,
                     Eigen::VectorXd& f,
-                    Eigen::VectorXd& x);
+                    Eigen::VectorXd& x,
+                    bool ignoreUnknownError = false);
 
   /*!
    * Solve min 1/2 x' Q x + c' x
@@ -143,7 +147,8 @@ class OoqpEigenInterface
    */
   static bool solve(Eigen::SparseMatrix<double, Eigen::RowMajor>& Q,
                     Eigen::VectorXd& c,
-                    Eigen::VectorXd& x);
+                    Eigen::VectorXd& x,
+                    bool ignoreUnknownError = false);
 
   /*!
    * Change to true to print debug information.

--- a/src/OoqpEigenInterface.cpp
+++ b/src/OoqpEigenInterface.cpp
@@ -179,7 +179,7 @@ bool OoqpEigenInterface::solve(Eigen::SparseMatrix<double, Eigen::RowMajor>& Q,
   // Solve.
   int status = s->solve(prob, vars, resid);
 
-  if (ignoreUnknownError || (status == SUCCESSFUL_TERMINATION))
+  if ((status == SUCCESSFUL_TERMINATION) || (ignoreUnknownError && (status == UNKNOWN)))
     vars->x->copyIntoArray(&x.coeffRef(0));
 
   if(isInDebugMode()) printSolution(status, x);
@@ -191,7 +191,7 @@ bool OoqpEigenInterface::solve(Eigen::SparseMatrix<double, Eigen::RowMajor>& Q,
   delete prob;
   delete qp;
 
-  return (status == SUCCESSFUL_TERMINATION || (ignoreUnknownError && (status == UNKNOWN)));
+  return ((status == SUCCESSFUL_TERMINATION) || (ignoreUnknownError && (status == UNKNOWN)));
 }
 
 bool OoqpEigenInterface::solve(Eigen::SparseMatrix<double, Eigen::RowMajor>& Q,


### PR DESCRIPTION
OOQP sometimes retuns an unknown error,  but the solution is still good. A flag can be set to ignore that error.