### PR TITLE
fixed wrong dependencies in cmake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(ooqpei
 	src/OoqpEigenInterface.cpp
 	src/QuadraticProblemFormulation.cpp 
 )
-add_dependencies(ooqpei ooqp_catkin)
+
 target_link_libraries(ooqpei 
     ${catkin_LIBRARIES}
 )

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>ooqp_eigen_interface</name>
   <version>0.0.0</version>
   <description>ooqp_eigen_interface</description>
@@ -9,8 +9,7 @@
   <author email="gehrinch@ethz.ch">Christian Gehring</author>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>eigen</build_depend>
-  <build_depend>ooqp_catkin</build_depend>
-  <run_depend>ooqp_catkin</run_depend>
+  <build_export_depend>eigen</build_export_depend>
+  <depend>ooqp_catkin</depend>
   <test_depend>gtest</test_depend>
 </package>


### PR DESCRIPTION
This should get rid of the warnings when compiling for xenail / kinetic